### PR TITLE
Add src flag to sonarlint cmd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,5 @@ USER app
 ENTRYPOINT []
 WORKDIR /code-read-write
 CMD cp -R /code/* . && \
-  /usr/src/app/dest/bin/sonarlint
+  /usr/src/app/dest/bin/sonarlint \
+  --src '**/*.{js,py,php,java}'


### PR DESCRIPTION
To limit what file extensions SonarLint looks at and thus limit the mess
in stderr.