### PR TITLE
Run sonarlint with debug flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ ENTRYPOINT []
 WORKDIR /code-read-write
 CMD cp -R /code/* . && \
   /usr/src/app/dest/bin/sonarlint \
-  --src '**/*.{js,py,php,java}'
+  --src '**/*.{js,py,php,java}' --debug


### PR DESCRIPTION
Trying to debug why some runs exit 1 only in builder. Thinking
it's a memory issue but this should confirm or deny.