### PR TITLE
Fallback to line 1 when file location is not provided by sonar

### DIFF
--- a/src/main/java/cc/models/Lines.java
+++ b/src/main/java/cc/models/Lines.java
@@ -12,8 +12,10 @@ class Lines {
     }
 
     public static Lines from(Issue issue) {
-        if(issue.getStartLine() == null || issue.getEndLine() == null) {
-            return null;
+        if (issue.getStartLine() == null || issue.getEndLine() == null) {
+            System.err.println("File location was not provided, defaulting to line 1.");
+            System.err.println(issue);
+            return new Lines(1, 1);
         }
         return new Lines(issue.getStartLine(), issue.getEndLine());
     }

--- a/src/test/java/cc/models/LinesTest.java
+++ b/src/test/java/cc/models/LinesTest.java
@@ -1,0 +1,17 @@
+package cc.models;
+
+import org.junit.Test;
+import support.fakes.FakeIssue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinesTest {
+
+    @Test
+    public void default_to_line_1() throws Exception {
+        FakeIssue issue = new FakeIssue("path", null, null);
+        Lines lines = Lines.from(issue);
+        assertThat(lines.begin).isEqualTo(1);
+        assertThat(lines.end).isEqualTo(1);
+    }
+}

--- a/src/test/java/cc/report/JsonReportTest.java
+++ b/src/test/java/cc/report/JsonReportTest.java
@@ -49,9 +49,10 @@ public class JsonReportTest {
     }
 
     @Test
-    public void does_not_include_unknown_location() throws Exception {
+    public void unknown_location_defaults_to_first_line() throws Exception {
         executeReport("major", new FakeIssue("file.java", null, null));
-        assertThat(output.stdout.toString()).doesNotContain("lines");
+        assertThat(output.stdout.toString()).contains("\"lines\":{\"begin\":1,\"end\":1}");
+        assertThat(output.stderr.toString()).contains("File location was not provided, defaulting to line 1");
     }
 
     void executeReport(String severity, FakeIssue issue) {


### PR DESCRIPTION
```
D, [2017-10-17T10:56:31.281470 #1] DEBUG -- : engine stderr: File location was not provided, defaulting to line 1.
D, [2017-10-17T10:56:31.281574 #1] DEBUG -- : engine stderr: [rule=squid:S1220, severity=MINOR, file=/code/multiple_paths/Main.java]
```