### PR TITLE
Revert "Renamed wrapper (#51)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,10 @@ engines:
 ## Sonar Documentation
 
 http://www.sonarlint.org/commandline
-
 http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
 
 Issue Tracker: http://jira.sonarsource.com/browse/SLCLI
 
 ## Copyright
-
-This engine is developed by Code Climate using [SonarLint](http://www.sonarlint.org/commandline), it is not endorsed by SonarSoruce.
 
 See [LICENSE](LICENSE)

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ build.dependsOn(infra)
 test.dependsOn(infra)
 
 dependencies {
-    compile("com.github.codeclimate:codeclimate-ss-analyzer-wrapper:master-SNAPSHOT")
+    compile("com.github.codeclimate:sonar-wrapper:master-SNAPSHOT")
 
     // Plugins
     compile("org.sonarsource.java:sonar-java-plugin:4.14.0.11784")


### PR DESCRIPTION
This reverts commit f43e380d6aa38c81da50ffe27c38796b3643cdab.

There are 2 test failures in the `master` branch:

    integration.JavaSourceVersion >
      specify_java_source_version_through_config FAILED

    integration.SanityCheckTest >
      executeJavaLibFixture FAILED

Reverting this commit puts the build back in a good state, and there's a
chance it also addresses codeclimate/codeclimate#827.

Before:

    codeclimate analyze -e sonar-java
    Starting analysis
    Running sonar-java: Done!
    error: (CC::CLI::Analyze::EngineFailure) engine sonar-java failed
    with status 99 and stderr
    engine produced invalid output: {:message=>"Invalid JSON",
    :output=>"INFO: Java 1.8.0_111-internal Oracle Corporation (64-bit)
    …

After:

    codeclimate analyze -e sonar-java
    Starting analysis
    Running sonar-java: Done!
    …
    Analysis complete! Found 76 issues.