### PR TITLE
QUA-431: use the wrapper's beta branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ build.dependsOn(infra)
 test.dependsOn(infra)
 
 dependencies {
-    implementation("com.github.codeclimate:codeclimate-ss-analyzer-wrapper:sonar-wrapper-update-SNAPSHOT")
+    implementation("com.github.codeclimate:codeclimate-ss-analyzer-wrapper:beta-SNAPSHOT")
 
     // Plugins
     implementation("org.sonarsource.java:sonar-java-plugin:6.15.1.26025")


### PR DESCRIPTION
This PR changes build.gradle to use codeclimate-ss-analyzer-wrapper's beta branch