### PR TITLE
QUA 431: allow beta branch in release_images step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
             - build
           filters:
             branches:
-              only: /master|channel\/[\w-]+/
+              only: /master|beta|channel\/[\w-]+/
 
 notify:
   webhooks:


### PR DESCRIPTION
This PR allows circleCI to release a docker image if checked out on the beta branch