### PR TITLE
Set up custom webhook for Shipbot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+
+init: &init
+  run:
+    name: init
+    command: |
+      echo '. .circleci/shared.bash' >> "$BASH_ENV"
+      . .circleci/shared.bash
+
 jobs:
   build:
     machine:
@@ -20,6 +28,7 @@ jobs:
     working_directory: ~/codeclimate/codeclimate-sonar-java
     steps:
       - checkout
+      - *init
       - run:
           name: Validate owner
           command: |
@@ -36,6 +45,7 @@ jobs:
             docker tag codeclimate/codeclimate-sonar-java \
               us.gcr.io/code-climate/codeclimate-sonar-java:b$CIRCLE_BUILD_NUM
             docker push us.gcr.io/code-climate/codeclimate-sonar-java:b$CIRCLE_BUILD_NUM
+      - run: send_webhook
 
 workflows:
   version: 2
@@ -48,7 +58,3 @@ workflows:
           filters:
             branches:
               only: /master|channel\/[\w-]+/
-
-notify:
-  webhooks:
-    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+function commiter_email() {
+  set +x
+  git log -n 1 --format='%ae'
+  set -x
+}
+
+function webhook_payload() {
+  set +x
+  COMMITER_EMAIL=$(commiter_email)
+  CURRENT_DATE=$(date)
+  jq --null-input \
+    --arg reponame $CIRCLE_PROJECT_REPONAME \
+    --arg username $CIRCLE_PROJECT_USERNAME \
+    --arg branch $CIRCLE_BRANCH \
+    --arg build_num $CIRCLE_BUILD_NUM \
+    --arg build_url $CIRCLE_BUILD_URL \
+    --arg author_email $COMMITER_EMAIL \
+    --arg end_time "$CURRENT_DATE" \
+    '{
+      "payload": {
+        "status": "success",
+        "outcome":"success",
+        "username": $username,
+        "reponame": $reponame,
+        "branch": $branch,
+        "build_num": $build_num,
+        "build_url": $build_url,
+        "author_email": $author_email,
+        "steps": [
+          {
+            "actions": [
+              {"end_time": $end_time }
+            ]
+          }
+        ]
+      }
+    }'
+  set -x
+}
+
+function send_webhook() {
+  set +x
+  PAYLOAD=$(webhook_payload)
+  curl -i -X POST https://cc-slack-proxy.herokuapp.com/circle \
+    -H 'Content-Type: application/json' \
+    -d "$PAYLOAD"
+  set -x
+}


### PR DESCRIPTION
Some days ago we discovered that CircleCI stopped sending these webhhoks to the `cc-slack-proxy` server. We contacted CircleCi's support team and they shared that we should be using CircleCi's v2 of their webhooks, which are set either via the web UI or API. This webhooks v2 came with a different payload, and in order to avoid us changes on the `cc-slack-proxy` and on `shipbot` to support this new payload we opted for temporary using a custom webhook that simulates the old webhooks.
