### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,41 @@ jobs:
       - run:
           name: Test
           command: make test
+
+  release_images:
+    machine:
+      docker_layer_caching: true
+    working_directory: ~/codeclimate/codeclimate-sonar-java
+    steps:
+      - checkout
+      - run:
+          name: Validate owner
+          command: |
+            if [ "$CIRCLE_PROJECT_USERNAME" -ne "codeclimate" ]
+            then
+              echo "Skipping release for non-codeclimate branches"
+              circleci step halt
+            fi
+      - run: make image
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - run:
+          name: Push image to Dockerhub
+          command: |
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build
+      - release_images:
+          context: Quality
+          requires:
+            - build
+          filters:
+            branches:
+              only: /master|channel\/[\w-]+/
+
 notify:
   webhooks:
     - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 MAINTAINER Code Climate
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: image test
+.PHONY: image test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-sonar-java
+RELEASE_REGISTRY ?= codeclimate
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
 	docker run --rm -ti -w /usr/src/app -u root $(IMAGE_NAME) gradle clean test
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-sonar-java:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-sonar-java:$(RELEASE_TAG)


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.

Also, change base image to `openjdk:8-jdk-alpine`. `java:8-jdk-alpine` no longer exists.