### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR (beta)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag codeclimate/codeclimate-sonar-java \
-              us.gcr.io/code-climate/codeclimate-sonar-java:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-sonar-java:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
       - run: send_webhook
 
 workflows:
@@ -53,6 +52,7 @@ workflows:
     jobs:
       - build
       - release_images:
+          context: Quality
           requires:
             - build
           filters:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: image test
+.PHONY: image test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-sonar-java
+RELEASE_REGISTRY ?= codeclimate
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
@@ -10,3 +15,7 @@ analyze-fixtures:
 
 test: image
 	docker run --rm -ti -w /usr/src/app -u root $(IMAGE_NAME) gradle clean test
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-sonar-java:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-sonar-java:$(RELEASE_TAG)


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.